### PR TITLE
fix: shabbos yuntif does not have a parsha

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+    extends: ["@commitlint/config-conventional"],
+};

--- a/src/Getters/Getters.php
+++ b/src/Getters/Getters.php
@@ -2,11 +2,25 @@
 
 namespace Zman\Getters;
 
+use Carbon\Carbon;
+
 trait Getters
 {
     use MDY;
     use Parsha;
     use Holidays;
+
+    /**
+     * Get the date of the next Shabbos.
+     *
+     * @return $this
+     */
+    public function comingShabbos()
+    {
+        return $this->dayOfWeek !== Carbon::SATURDAY
+            ? (clone $this)->next('Saturday')
+            : $this;
+    }
 
     /**
      * Attach properties to the Zman object so

--- a/src/Getters/Getters.php
+++ b/src/Getters/Getters.php
@@ -18,8 +18,8 @@ trait Getters
     public function comingShabbos()
     {
         return $this->dayOfWeek !== Carbon::SATURDAY
-            ? (clone $this)->next('Saturday')
-            : $this;
+            ? $this->copy()->next('Saturday')
+            : $this->copy();
     }
 
     /**

--- a/src/Getters/Parsha.php
+++ b/src/Getters/Parsha.php
@@ -51,11 +51,16 @@ trait Parsha
     /**
      * Get the current week's Parsha.
      *
-     * @return string
+     * @return string|null
      */
     private function parshasHashavua($galus = null)
     {
         $galus = $this->getGalusMode($galus);
+
+        // Yuntif does not have a parsha
+        if ($this->comingShabbos()->isYuntif()) {
+            return null;
+        }
 
         // Breishis is the first Shabbos after Simchas Torah
         $simchasTorah = self::dayOfSimchasTorah($this->jewishYear, $galus);

--- a/src/Getters/Parsha.php
+++ b/src/Getters/Parsha.php
@@ -58,7 +58,7 @@ trait Parsha
         $galus = $this->getGalusMode($galus);
 
         // Yuntif does not have a parsha
-        if ($this->comingShabbos()->isYuntif()) {
+        if ($this->comingShabbos()->isYuntif() || $this->comingShabbos()->isCholHamoed()) {
             return null;
         }
 

--- a/tests/Getters/ParshiosTest.php
+++ b/tests/Getters/ParshiosTest.php
@@ -261,7 +261,7 @@ class ParshiosTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('Nitzavim', Zman::parse('9/25/19')->parsha);
         $this->assertEquals('Vayelech', Zman::parse('10/2/19')->parsha);
         $this->assertEquals('Haazinu', Zman::parse('10/7/19')->parsha);
-        $this->assertEquals('Vezos Haberacha', Zman::parse('10/16/19')->parsha);
+        $this->assertEquals(null, Zman::parse('10/16/19')->parsha);
         $this->assertEquals('נצבים', Zman::parse('9/25/19')->parshaHebrew);
         $this->assertEquals('וילך', Zman::parse('10/2/19')->parshaHebrew);
         $this->assertEquals('האזינו', Zman::parse('10/7/19')->parshaHebrew);

--- a/tests/Getters/ParshiosTest.php
+++ b/tests/Getters/ParshiosTest.php
@@ -13,6 +13,7 @@ class ParshiosTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('Breishis', Zman::parse('10/27/16')->parsha);
         $this->assertEquals('Breishis', Zman::parse('10/28/16')->parsha);
         $this->assertEquals('Breishis', Zman::parse('10/29/16')->parsha);
+
         $this->assertEquals('בראשית', Zman::parse('10/26/16')->parshaHebrew);
 
         $this->assertNotEquals('Breishis', Zman::parse('10/30/16')->parsha);
@@ -120,7 +121,7 @@ class ParshiosTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('Shmini', Zman::parse('3/28/19')->parsha);
         $this->assertEquals('Tazria', Zman::parse('4/4/19')->parsha);
         $this->assertEquals('Metzora', Zman::parse('4/11/19')->parsha);
-        $this->assertEquals('Acharei Mos', Zman::parse('4/21/19')->parsha);
+        $this->assertEquals(null, Zman::parse('4/21/19')->parsha);
         $this->assertEquals('Acharei Mos', Zman::parse('4/29/19')->parsha);
         $this->assertEquals('Acharei Mos', Zman::parse('5/2/19')->parsha);
         $this->assertEquals('Kedoshim', Zman::parse('5/9/19')->parsha);
@@ -252,7 +253,7 @@ class ParshiosTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('Nitzavim', Zman::parse('9/29/16')->parsha);
         $this->assertEquals('Vayelech', Zman::parse('10/6/16')->parsha);
         $this->assertEquals('Haazinu', Zman::parse('9/21/17')->parsha);
-        $this->assertEquals('Vezos Haberacha', Zman::parse('9/26/17')->parsha);
+        $this->assertEquals(null, Zman::parse('9/26/17')->parsha);
         $this->assertEquals('נצבים', Zman::parse('9/29/16')->parshaHebrew);
         $this->assertEquals('וילך', Zman::parse('10/6/16')->parshaHebrew);
         $this->assertEquals('האזינו', Zman::parse('9/21/17')->parshaHebrew);
@@ -272,5 +273,13 @@ class ParshiosTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('Haazinu', Zman::parse('9/21/17')->parsha);
 
         $this->assertEquals('האזינו', Zman::parse('9/21/17')->parshaHebrew);
+    }
+
+    /** @test */
+    public function yuntif_does_not_have_a_parsha()
+    {
+        $this->assertEquals('Tzav', Zman::parse('03/25/21')->parsha);
+        $this->assertEquals(null, Zman::parse('04/02/21')->parsha);
+        $this->assertEquals('Shmini', Zman::parse('04/04/21')->parsha);
     }
 }


### PR DESCRIPTION
Fixes #16.

Parsha will be returned as `null` if there is no parsha that week (the case of yuntif). 